### PR TITLE
Fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ All changes in `master` branch are automatically deployed to the above URL.
 gem install asciidoctor
 ```
 
-* AciiDoctor (pdf)
+* AsciiDoctor (pdf)
 
 ```bash
 gem install --pre asciidoctor-pdf

--- a/src/do/do-pull-request.adoc
+++ b/src/do/do-pull-request.adoc
@@ -1,6 +1,6 @@
 === Pull Requests
 
-If you spent the time doing the work, make sure you add a description to your your Pull Request to make it easier for the reviewer to digest your work. Raise an Issue first so a plan of action can be discussed before you begin the work and to remind yourself of the goals set out in that task.
+If you spent the time doing the work, make sure you add a description to your Pull Request to make it easier for the reviewer to digest your work. Raise an Issue first so a plan of action can be discussed before you begin the work and to remind yourself of the goals set out in that task.
 
 Pull Requests should be linked to the original Issue it is trying to solve. This can be done with using `#` followed by the *Issue No*, e.g. `#123`. The Issue description will contain the information before, therefore the Pull Request description should contain the information after the changes. Include visual material too, for example diagrams & screenshots.
 


### PR DESCRIPTION
## Summary
- correct a typo in the README (AsciiDoctor spelling)
- remove duplicate word in pull request guidelines

## Testing
- `make html` *(fails: asciidoctor missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f67fb97bc832f8436d4df1b51cd1a